### PR TITLE
[optimisation, n/a] optimised tests

### DIFF
--- a/test/unit/api/ping.test.js
+++ b/test/unit/api/ping.test.js
@@ -31,15 +31,9 @@ describe('src/api/ping', () => {
     uptime: fakeUptime
   }
 
-  const resetStubs = () => {
-    res.json.resetHistory()
-  }
-
   before(() => {
     ping(req, res)
   })
-
-  after(resetStubs)
 
   it('calls res.json with the correct data', () => {
     expect(res.json).to.have.been.calledWith(expected)

--- a/test/unit/api/v1/hello.test.js
+++ b/test/unit/api/v1/hello.test.js
@@ -6,10 +6,6 @@ const hello = require('src/api/v1/hello')
 describe('src/api/v1/hello', () => {
   const res = mockResponse()
 
-  const resetStubs = () => {
-    res.json.resetHistory()
-  }
-
   context('when a valid name is provided', () => {
     const name = 'Dave Sag'
     const req = mockRequest({ params: { name } })
@@ -18,8 +14,6 @@ describe('src/api/v1/hello', () => {
     before(() => {
       hello(req, res)
     })
-
-    after(resetStubs)
 
     it('calls res.json with the correct data', () => {
       expect(res.json).to.have.been.calledWith(expected)

--- a/test/unit/api/versions.test.js
+++ b/test/unit/api/versions.test.js
@@ -14,15 +14,9 @@ describe('src/api/versions', () => {
     }
   ]
 
-  const resetStubs = () => {
-    res.json.resetHistory()
-  }
-
   before(() => {
     versions(req, res)
   })
-
-  after(resetStubs)
 
   it('calls res.json with the correct data', () => {
     expect(res.json).to.have.been.calledWith(expected)

--- a/test/unit/server.test.js
+++ b/test/unit/server.test.js
@@ -5,12 +5,13 @@ const proxyquire = require('proxyquire')
 const mockLogger = require('test/utils/mockLogger')
 
 describe('src/server', () => {
+  const logger = mockLogger()
   const mockApp = { listen: stub() }
   const mockMakeApp = stub()
 
   const server = proxyquire('src/server', {
     'src/utils/makeApp': mockMakeApp,
-    'src/utils/logger': mockLogger
+    'src/utils/logger': logger
   })
 
   const mockServer = 'a server'
@@ -21,12 +22,6 @@ describe('src/server', () => {
     mockMakeApp.resolves(mockApp)
     mockApp.listen.resolves(mockServer)
     outcome = await server.start()
-  })
-
-  after(() => {
-    mockMakeApp.resetHistory()
-    mockApp.listen.resetHistory()
-    mockLogger.debug.resetHistory()
   })
 
   it('invoked app.listen', () => {

--- a/test/unit/utils/api/apiDefinition.test.js
+++ b/test/unit/utils/api/apiDefinition.test.js
@@ -8,11 +8,6 @@ describe('src/utils/api/apiDefinition', () => {
   const fakeSummary = { ...fakeDoc, summary: true }
   const mockSummarise = stub().returns(fakeSummary)
 
-  const resetStubs = () => {
-    mockYAML.load.resetHistory()
-    mockSummarise.resetHistory()
-  }
-
   let apiDefinition
   let apiSummary
 
@@ -25,8 +20,6 @@ describe('src/utils/api/apiDefinition', () => {
       }
     ))
   })
-
-  after(resetStubs)
 
   it('loads the api doc', () => {
     expect(mockYAML.load).to.have.been.calledWith('api.yml')

--- a/test/unit/utils/api/apiValidator.test.js
+++ b/test/unit/utils/api/apiValidator.test.js
@@ -1,12 +1,12 @@
 const { expect } = require('chai')
-const sinon = require('sinon')
+const { stub, match } = require('sinon')
 const proxyquire = require('proxyquire')
 
 const mockLogger = require('test/utils/mockLogger')
 
 describe('src/utils/api/apiValidator', () => {
   const logger = mockLogger()
-  const validator = sinon.stub()
+  const validator = stub()
   const apiValidator = proxyquire('src/utils/api/apiValidator', {
     'swagger-express-validator': validator,
     'src/utils/logger': logger
@@ -20,7 +20,7 @@ describe('src/utils/api/apiValidator', () => {
 
   it('called validator', () => {
     expect(validator).to.have.been.calledWith(
-      sinon.match({
+      match({
         schema,
         validateRequest: true,
         validateResponse: true

--- a/test/unit/utils/api/apiValidator.test.js
+++ b/test/unit/utils/api/apiValidator.test.js
@@ -5,16 +5,12 @@ const proxyquire = require('proxyquire')
 const mockLogger = require('test/utils/mockLogger')
 
 describe('src/utils/api/apiValidator', () => {
-  const mockValidator = sinon.stub()
+  const logger = mockLogger()
+  const validator = sinon.stub()
   const apiValidator = proxyquire('src/utils/api/apiValidator', {
-    'swagger-express-validator': mockValidator,
-    'src/utils/logger': mockLogger
+    'swagger-express-validator': validator,
+    'src/utils/logger': logger
   })
-
-  const resetStubs = () => {
-    mockLogger.error.resetHistory()
-    mockValidator.resetHistory()
-  }
 
   const schema = 'some-schema'
 
@@ -22,10 +18,8 @@ describe('src/utils/api/apiValidator', () => {
     apiValidator(schema)
   })
 
-  after(resetStubs)
-
   it('called validator', () => {
-    expect(mockValidator).to.have.been.calledWith(
+    expect(validator).to.have.been.calledWith(
       sinon.match({
         schema,
         validateRequest: true,

--- a/test/unit/utils/api/summariseApi.test.js
+++ b/test/unit/utils/api/summariseApi.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const { match, restore, stub } = require('sinon')
+const { match, stub } = require('sinon')
 const proxyquire = require('proxyquire')
 
 const fakePaths = require('test/utils/fakePaths')
@@ -102,10 +102,6 @@ describe('src/utils/api/summariseApi', () => {
   before(() => {
     summarise.returns(paths)
     result = summariseApi(fakeApi)
-  })
-
-  after(() => {
-    restore()
   })
 
   it('called summarisePaths', () => {

--- a/test/unit/utils/genericErrors.test.js
+++ b/test/unit/utils/genericErrors.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const sinon = require('sinon')
+const { stub, resetHistory } = require('sinon')
 const proxyquire = require('proxyquire')
 const { mockRequest, mockResponse } = require('mock-req-res')
 const HttpError = require('node-http-error')
@@ -9,21 +9,15 @@ const mockLogger = require('test/utils/mockLogger')
 const ERRORS = require('src/errors')
 
 describe('src/utils/genericErrors', () => {
+  const logger = mockLogger()
   const genericErrors = proxyquire('src/utils/genericErrors', {
-    'src/utils/logger': mockLogger
+    'src/utils/logger': logger
   })
 
   const status = BAD_REQUEST
   const error = new HttpError(status, 'oops')
   const res = mockResponse()
-  const next = sinon.stub()
-
-  const resetStubs = () => {
-    next.resetHistory()
-    mockLogger.error.resetHistory()
-    res.status.resetHistory()
-    res.json.resetHistory()
-  }
+  const next = stub()
 
   context('when other error headers have already been sent', () => {
     before(() => {
@@ -31,7 +25,7 @@ describe('src/utils/genericErrors', () => {
       genericErrors(error, null, res, next)
     })
 
-    after(resetStubs)
+    after(resetHistory)
 
     it('called next with the error', () => {
       expect(next).to.have.been.calledOnce
@@ -59,12 +53,12 @@ describe('src/utils/genericErrors', () => {
         genericErrors(error, req, res, next)
       })
 
-      after(resetStubs)
+      after(resetHistory)
 
       it('calls logger.error with the ERRORS.GENERIC_ERROR', () => {
-        expect(mockLogger.error).to.have.been.calledOnce
-        expect(mockLogger.error.args[0][0]).to.equal(ERRORS.GENERIC_ERROR())
-        expect(mockLogger.error.args[0][1]).to.deep.equal(error)
+        expect(logger.error).to.have.been.calledOnce
+        expect(logger.error.args[0][0]).to.equal(ERRORS.GENERIC_ERROR())
+        expect(logger.error.args[0][1]).to.deep.equal(error)
       })
 
       it('calls res.status with the status', () => {
@@ -83,13 +77,11 @@ describe('src/utils/genericErrors', () => {
         genericErrors(error, req, res, next)
       })
 
-      after(resetStubs)
+      after(resetHistory)
 
       it('calls logger.error with the ERRORS.GENERIC_ERROR', () => {
-        expect(mockLogger.error).to.have.been.calledOnce
-        expect(mockLogger.error.args[0][0]).to.equal(
-          ERRORS.GENERIC_ERROR('test')
-        )
+        expect(logger.error).to.have.been.calledOnce
+        expect(logger.error.args[0][0]).to.equal(ERRORS.GENERIC_ERROR('test'))
       })
 
       it('calls res.status with the status', () => {
@@ -110,14 +102,14 @@ describe('src/utils/genericErrors', () => {
         genericErrors(genericError, req, res, next)
       })
 
-      after(resetStubs)
+      after(resetHistory)
 
       it('calls logger.error with the ERRORS.GENERIC_ERROR', () => {
-        expect(mockLogger.error).to.have.been.calledOnce
-        expect(mockLogger.error.args[0][0]).to.equal(
+        expect(logger.error).to.have.been.calledOnce
+        expect(logger.error.args[0][0]).to.equal(
           ERRORS.GENERIC_ERROR('test', parent.name)
         )
-        expect(mockLogger.error.args[0][1]).to.deep.equal(genericError)
+        expect(logger.error.args[0][1]).to.deep.equal(genericError)
       })
 
       it('calls res.status with INTERNAL_SERVER_ERROR', () => {

--- a/test/unit/utils/makeApp.test.js
+++ b/test/unit/utils/makeApp.test.js
@@ -1,11 +1,11 @@
 const { expect } = require('chai')
-const sinon = require('sinon')
+const { stub, spy } = require('sinon')
 const proxyquire = require('proxyquire').noCallThru()
 
 describe('src/utils/makeApp', () => {
   const fakeCors = 'cors'
   const fakeBodyParser = {
-    json: sinon.stub().returns('json-parser')
+    json: stub().returns('json-parser')
   }
 
   const fakeErrorHandler = 'errorHandler'
@@ -14,13 +14,13 @@ describe('src/utils/makeApp', () => {
     apiDefinition: { test: 'just a test' },
     '@noCallThru': true
   }
-  const mockApiValidator = sinon.stub().returns('api-validator')
-  const mockConnect = sinon.spy()
+  const mockApiValidator = stub().returns('api-validator')
+  const mockConnect = spy()
   const mockApiConnector = () => mockConnect
-  const mockCors = sinon.stub().returns(fakeCors)
+  const mockCors = stub().returns(fakeCors)
   const fakeNotFoundError = 'not found error'
-  const mockUse = sinon.spy()
-  const mockSet = sinon.spy()
+  const mockUse = spy()
+  const mockSet = spy()
   const fakeExpress = () => ({
     use: mockUse,
     set: mockSet
@@ -37,22 +37,11 @@ describe('src/utils/makeApp', () => {
     'src/utils/genericErrors': fakeErrorHandler
   })
 
-  const resetStubs = () => {
-    fakeBodyParser.json.resetHistory()
-    mockCors.resetHistory()
-    mockUse.resetHistory()
-    mockSet.resetHistory()
-    mockApiValidator.resetHistory()
-    mockConnect.resetHistory()
-  }
-
   let app
 
   before(async () => {
     app = await makeApp()
   })
-
-  after(resetStubs)
 
   it('uses cors', () => {
     expect(mockCors).to.have.been.calledOnce

--- a/test/unit/utils/notFoundError.test.js
+++ b/test/unit/utils/notFoundError.test.js
@@ -9,16 +9,9 @@ describe('src/utils/notFoundError', () => {
   const res = mockResponse()
   const req = mockRequest()
 
-  const resetStubs = () => {
-    res.status.resetHistory()
-    res.json.resetHistory()
-  }
-
   before(() => {
     notFoundError(req, res)
   })
-
-  after(resetStubs)
 
   it('called res.status with NOT_FOUND status', () => {
     expect(res.status).to.have.been.calledWith(NOT_FOUND)

--- a/test/utils/mockLogger.js
+++ b/test/utils/mockLogger.js
@@ -1,9 +1,9 @@
 const { spy } = require('sinon')
 
-const mockLogger = {
+const mockLogger = () => ({
   debug: spy(),
   error: spy(),
   info: spy()
-}
+})
 
 module.exports = mockLogger


### PR DESCRIPTION
* replaced `mockLogger` with a function so the spies don't persist between tests
* removed superfluous reseting of stub histories.
* remove call to Sinon's `restore` function as it breaks other tests.
